### PR TITLE
Composer: update PHPUnit Polyfills version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.6",
-        "yoast/phpunit-polyfills": "^0.2.0",
+        "yoast/phpunit-polyfills": "^1.0.0",
         "brain/monkey": "^2.6.0"
     },
     "require-dev" : {


### PR DESCRIPTION
The PHPUnit Polyfills repo has released version 1.0.0.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/1.0.0