### PR TITLE
Composer: upgrade the PHPUnit Polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.6",
-        "yoast/phpunit-polyfills": "^1.0.0",
+        "yoast/phpunit-polyfills": "^1.0.1",
         "brain/monkey": "^2.6.0"
     },
     "require-dev" : {


### PR DESCRIPTION
Setting the minimum version to `1.0.1` ensures install will comply with the minimum version expected for WordPress 5.9.