### PR TITLE
Composer: update Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "brain/monkey": "^2.6.0"
     },
     "require-dev" : {
-        "php-parallel-lint/php-parallel-lint": "^1.3.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "yoast/yoastcs": "^2.1.0"
     },


### PR DESCRIPTION
Update the Parallel Lint `dev` dependency to use v `1.3.1` as a minimum. The new release has improved PHP 8.1 support.

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.1