### PR TITLE
Update to YoastCS 2.2.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,6 +34,13 @@
 	-->
 
 	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WPTestUtils"/>
+			</property>
+		</properties>
+
 		<!-- Use CamelCaps file names to be more in line with the naming conventions used in PHPUnit. -->
 		<exclude name="Yoast.Files.FileName"/>
 
@@ -90,6 +97,11 @@
 		<exclude-pattern>/src/*/bootstrap*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Declaring a few WordPress native constants. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
+		<exclude-pattern>/src/BrainMonkey/bootstrap\.php$</exclude-pattern>
+	</rule>
+
 	<!-- Allow for camelCase method and variable names to be more in line with PHPUnit and BrainMonkey. -->
 	<rule ref="WordPress.NamingConventions.ValidFunctionName">
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>
@@ -98,6 +110,15 @@
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Ignore word count for object names in tests. -->
+	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Test fixtures are not the actual tests. -->
+	<rule ref="Yoast.Commenting.TestsHaveCoversTag">
+		<exclude-pattern>/tests/*/Fixtures/*\.php$</exclude-pattern>
+	</rule>
 
 	<!--
 	#############################################################################

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,7 @@
         "brain/monkey": "^2.6.0"
     },
     "require-dev" : {
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/yoastcs": "^2.1.0"
+        "yoast/yoastcs": "^2.2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
###  Composer: update to YoastCS 2.2.0

... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Ref: https://github.com/Yoast/yoastcs/releases

### PHPCS: minor tweaks to the ruleset


* Ensure all code in the global namespace is prefixed - with the exception of the WP constants declarations in the BrainMonket test bootstrap.
* Ignore camelCase object name depth rules for the tests.
* For fixtures containing test methods, no `@covers` tags are needed. Those are not the real tests.

