### PR TITLE
Integration test bootstrap: add fall-back support for typical WP-CLI setup

### DIFF
--- a/src/WPIntegration/bootstrap-functions.php
+++ b/src/WPIntegration/bootstrap-functions.php
@@ -52,6 +52,8 @@ function get_path_to_wp_test_dir() {
 				return $tests_dir;
 			}
 		}
+
+		unset( $tests_dir );
 	}
 
 	if ( \getenv( 'WP_DEVELOP_DIR' ) !== false ) {
@@ -65,6 +67,8 @@ function get_path_to_wp_test_dir() {
 				return $dev_dir . 'tests/phpunit/';
 			}
 		}
+
+		unset( $dev_dir );
 	}
 
 	/*
@@ -77,6 +81,23 @@ function get_path_to_wp_test_dir() {
 		$tests_dir = \realpath( $tests_dir );
 		if ( $tests_dir !== false ) {
 			return $normalize_path( $tests_dir ) . '/';
+		}
+
+		unset( $tests_dir );
+	}
+
+	/*
+	 * Last resort: see if this is a typical WP-CLI scaffold command set-up where a subset of
+	 * the WP test files have been put in the system temp directory.
+	 */
+	$tests_dir = sys_get_temp_dir() . '/wordpress-tests-lib';
+	$tests_dir = \realpath( $tests_dir );
+	if ( $tests_dir !== false ) {
+		$tests_dir = $normalize_path( $tests_dir ) . '/';
+		if ( \is_dir( $tests_dir ) === true
+			&& @\file_exists( $tests_dir . 'includes/bootstrap.php' )
+		) {
+			return $tests_dir;
 		}
 	}
 


### PR DESCRIPTION
As the WP-CLI `scaffold` command is an often-used basis for setting up the integration tests, this commit adds a native check to WP Test Utils in the integration tests `get_path_to_wp_test_dir()` function for the WP native test bootstrap in the typical location used by the WP-CLI `scaffold` `install-wp-tests.sh` script.

This means that if the `install-wp-tests.sh` script is used without adjustments, the path to the WP native test bootstrap should be findable by WP Test Utils without needing to set the `WP_TESTS_DIR` constant.

Fixes #12


@swissspidy @GaryJones Would be great if either of you had a chance to look this over/test it!