### PR TITLE
TestCase: update for PHPUnit Polyfills 1.0.0

### DIFF
--- a/src/WPIntegration/TestCase.php
+++ b/src/WPIntegration/TestCase.php
@@ -4,11 +4,14 @@ namespace Yoast\WPTestUtils\WPIntegration;
 
 use WP_UnitTestCase;
 use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
@@ -26,11 +29,14 @@ use Yoast\WPTestUtils\Helpers\ExpectOutputHelper;
 abstract class TestCase extends WP_UnitTestCase {
 
 	use AssertAttributeHelper;
+	use AssertClosedResource;
 	use AssertEqualsSpecializations;
 	use AssertFileEqualsSpecializations;
 	use AssertionRenames;
 	use AssertIsType;
+	use AssertObjectEquals;
 	use AssertStringContains;
+	use EqualToSpecializations;
 	use ExpectExceptionMessageMatches;
 	use ExpectExceptionObject;
 	use ExpectOutputHelper;


### PR DESCRIPTION
Follow up to #11

As per the changelog of the PHPUnit Polyfills, version 1.0.0 introduced three new polyfill traits.

Those traits were not yet included in the `Yoast\WPTestUtils\WPIntegration\TestCase`. Fixed now.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/1.0.0