### PR TITLE
Add cross-version compatibility with WP 5.9 and WP < 5.9

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -102,6 +102,11 @@
 		<exclude-pattern>/src/BrainMonkey/bootstrap\.php$</exclude-pattern>
 	</rule>
 
+	<!-- These duplicate classes are by design. -->
+	<rule ref="Generic.Classes.DuplicateClassName">
+		<exclude-pattern>/src/WPIntegration/TestCase*\.php$</exclude-pattern>
+	</rule>
+
 	<!-- Allow for camelCase method and variable names to be more in line with PHPUnit and BrainMonkey. -->
 	<rule ref="WordPress.NamingConventions.ValidFunctionName">
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,10 @@
     "autoload": {
         "classmap": [
             "src/"
+        ],
+        "exclude-from-classmap": [
+            "/src/WPIntegration/TestCase.php",
+            "/src/WPIntegration/TestCaseNoPolyfills.php"
         ]
     },
     "autoload-dev" : {

--- a/src/WPIntegration/Autoload.php
+++ b/src/WPIntegration/Autoload.php
@@ -7,9 +7,12 @@ use PHPUnit\Runner\Version as PHPUnit_Version;
 /**
  * Custom autoloader.
  *
- * Autoloader file for the PHPUnit 9 MockObject classes.
+ * Autoloader file for the PHPUnit 9 MockObject classes as included in WP 5.6 - 5.8
+ * and the WP Test Utils Integration test TestCase.
  *
- * Hack around PHPUnit < 9.3 mocking not being compatible with PHP 8.
+ * - Hack around PHPUnit < 9.3 mocking not being compatible with PHP >= 8.
+ * - Load the most appropriate TestCase depending on the features available in the WP version
+ *   tests are being run against.
  *
  * This allows for cross-version compatibility with various PHP, PHPUnit and WP versions.
  *
@@ -17,6 +20,7 @@ use PHPUnit\Runner\Version as PHPUnit_Version;
  * as defined in the `src/WPIntegration/bootstrap-functions.php` file to register the autoloader.
  *
  * @since 0.2.0
+ * @since 1.0.0 Now also handles the loading of the WP Test Utils Integration TestCase.
  */
 final class Autoload {
 
@@ -26,10 +30,11 @@ final class Autoload {
 	 * @var string[] => true
 	 */
 	private static $supported_classes = [
-		'PHPUnit\Framework\MockObject\Builder\NamespaceMatch'  => true,
-		'PHPUnit\Framework\MockObject\Builder\ParametersMatch' => true,
-		'PHPUnit\Framework\MockObject\InvocationMocker'        => true,
-		'PHPUnit\Framework\MockObject\MockMethod'              => true,
+		'PHPUnit\\Framework\\MockObject\\Builder\\NamespaceMatch'  => true,
+		'PHPUnit\\Framework\\MockObject\\Builder\\ParametersMatch' => true,
+		'PHPUnit\\Framework\\MockObject\\InvocationMocker'         => true,
+		'PHPUnit\\Framework\\MockObject\\MockMethod'               => true,
+		'Yoast\\WPTestUtils\\WPIntegration\\TestCase'              => true,
 	];
 
 	/**
@@ -40,9 +45,29 @@ final class Autoload {
 	 * @return bool
 	 */
 	public static function load( $class_name ) {
+		if ( isset( self::$supported_classes[ $class_name ] ) === false ) {
+			// Bow out, not a class this autoloader handles.
+			return false;
+		}
 
+		if ( \strpos( $class_name, 'PHPUnit' ) === 0 ) {
+			return self::load_mockobject_class( $class_name );
+		}
+
+		return self::load_test_case();
+	}
+
+	/**
+	 * Loads the PHPUnit 9.x mock object classes as included with WP 5.6 - 5.8
+	 * when relevant.
+	 *
+	 * @param string $class_name The name of the class to load.
+	 *
+	 * @return bool
+	 */
+	private static function load_mockobject_class( $class_name ) {
 		if ( \PHP_VERSION_ID < 80000 ) {
-			// This autoloader is only needed when the tests are being run on PHP >= 8.0.
+			// The mock object autoloading is only needed when the tests are being run on PHP >= 8.0.
 			// Let the standard Composer autoloader handle things otherwise.
 			return false;
 		}
@@ -50,13 +75,8 @@ final class Autoload {
 		if ( \class_exists( PHPUnit_Version::class ) === false
 			|| \version_compare( PHPUnit_Version::id(), '8.0.0', '>=' )
 		) {
-			// This autoloader is only needed when the tests are being run on PHPUnit < 8
+			// The mock object autoloading is only needed when the tests are being run on PHPUnit < 8
 			// and won't work with PHPUnit 5 anyway.
-			return false;
-		}
-
-		if ( isset( self::$supported_classes[ $class_name ] ) === false ) {
-			// Bow out, not a class this autoloader handles.
 			return false;
 		}
 
@@ -66,7 +86,7 @@ final class Autoload {
 			return false;
 		}
 
-		// Try getting the overloaded file as included in WP 5.6/master.
+		// Try getting the overloaded file as included in WP 5.6 - 5.8.
 		$relative_filename = \strtr( \substr( $class_name, 18 ), '\\', \DIRECTORY_SEPARATOR ) . '.php';
 		$file              = \realpath( $wp_test_dir . 'includes/phpunit7/' . $relative_filename );
 
@@ -75,6 +95,24 @@ final class Autoload {
 		}
 
 		require_once $file;
+		return true;
+	}
+
+	/**
+	 * Loads the most appropriate test case depending on the WP version the tests are
+	 * being run against.
+	 *
+	 * @return bool
+	 */
+	private static function load_test_case() {
+		if ( \method_exists( 'WP_UnitTestCase', 'set_up' ) === false ) {
+			// Older WP version from before the test changes.
+			require_once __DIR__ . '/TestCase.php';
+			return true;
+		}
+
+		// WP 5.9 or a WP 5.2 - 5.8 version which includes the Polyfills and the fixture method wrappers.
+		require_once __DIR__ . '/TestCaseNoPolyfills.php';
 		return true;
 	}
 }

--- a/src/WPIntegration/TestCase.php
+++ b/src/WPIntegration/TestCase.php
@@ -24,7 +24,22 @@ use Yoast\WPTestUtils\Helpers\ExpectOutputHelper;
  * all relevant polyfills available to allow for using PHPUnit 9.x
  * assertion and expectation syntax.
  *
+ * This test case is suitable for use with:
+ * - WP < 5.2;
+ * - WP 5.2.0 - 5.2.12;
+ * - WP 5.3.0 - 5.3.9;
+ * - WP 5.4.0 - 5.4.7;
+ * - WP 5.5.0 - 5.5.6;
+ * - WP 5.6.0 - 5.6.5;
+ * - WP 5.7.0 - 5.7.3;
+ * - WP 5.8.0 - 5.8.1.
+ *
+ * The included autoloader will automatically load the correct test case for
+ * the WordPress version the tests are being run on.
+ *
  * @since 0.2.0
+ * @since 1.0.0 Added the snake_case wrapper methods, same as done in WP 5.2 - 5.8
+ *              in the backports.
  */
 abstract class TestCase extends WP_UnitTestCase {
 
@@ -42,4 +57,81 @@ abstract class TestCase extends WP_UnitTestCase {
 	use ExpectOutputHelper;
 	use ExpectPHPException;
 
+	/**
+	 * Wrapper method for the `set_up_before_class()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::set_up_before_class();
+	}
+
+	/**
+	 * Wrapper method for the `tear_down_after_class()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tearDownAfterClass() {
+		static::tear_down_after_class();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `set_up()` method for forward-compatibility with WP 5.9.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->set_up();
+	}
+
+	/**
+	 * Wrapper method for the `tear_down()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tearDown() {
+		$this->tear_down();
+		parent::tearDown();
+	}
+
+	/**
+	 * Wrapper method for the `assert_pre_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPreConditions() {
+		parent::assertPreConditions();
+		$this->assert_pre_conditions();
+	}
+
+	/**
+	 * Wrapper method for the `assert_post_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPostConditions() {
+		parent::assertPostConditions();
+		$this->assert_post_conditions();
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function set_up() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function tear_down() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_pre_conditions() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_post_conditions() {}
 }

--- a/src/WPIntegration/TestCaseNoPolyfills.php
+++ b/src/WPIntegration/TestCaseNoPolyfills.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WPTestUtils\WPIntegration;
+
+use WP_UnitTestCase;
+use Yoast\WPTestUtils\Helpers\ExpectOutputHelper;
+
+/**
+ * Basic test case for use with a WP Integration test test suite.
+ *
+ * This test case extends the WordPress native base test case and
+ * adds a limited set of test helper functions.
+ *
+ * The WordPress native base test case will include all relevant
+ * polyfills to allow for using PHPUnit 9.x assertion and expectation syntax.
+ *
+ * This test case is suitable for use with:
+ * - WP 5.2.13 and higher;
+ * - WP 5.3.10 and higher;
+ * - WP 5.4.8 and higher;
+ * - WP 5.5.7 and higher;
+ * - WP 5.6.6 and higher;
+ * - WP 5.7.4 and higher;
+ * - WP 5.8.1 and higher;
+ * - WP 5.9.0 and higher.
+ *
+ * The included autoloader will automatically load the correct test case for
+ * the WordPress version the tests are being run on.
+ *
+ * @since 1.0.0
+ */
+abstract class TestCase extends WP_UnitTestCase {
+
+	use ExpectOutputHelper;
+
+}

--- a/src/WPIntegration/bootstrap-functions.php
+++ b/src/WPIntegration/bootstrap-functions.php
@@ -120,6 +120,12 @@ function bootstrap_it() {
 	// Make sure the Composer autoload file has been generated.
 	namespace\check_composer_autoload_exists();
 
+	/*
+	 * Load the PHPUnit Polyfills autoload file before bootstrapping WordPress for compatibility
+	 * with the test changes per WP 5.9 (and backported to WP 5.2 - 5.8).
+	 */
+	require_once __DIR__ . '/../../../phpunit-polyfills/phpunitpolyfills-autoload.php';
+
 	// Load WordPress.
 	namespace\load_wp_test_bootstrap();
 
@@ -185,11 +191,16 @@ function load_composer_autoload() {
  * Verifies whether the Composer autoload file exists for a plugin which uses this libary
  * as a dependency.
  *
+ * @since 1.0.0 Also checks that the PHPUnit Polyfills autoload file exists, just to be sure.
+ *
  * @return void
  */
 function check_composer_autoload_exists() {
-	if ( @\file_exists( __DIR__ . '/../../../../autoload.php' ) === false ) {
-		echo \PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', \PHP_EOL;
+	if ( @\file_exists( __DIR__ . '/../../../../autoload.php' ) === false
+		&& @\file_exists( __DIR__ . '/../../../phpunit-polyfills/phpunitpolyfills-autoload.php' ) === false
+	) {
+		echo \PHP_EOL, 'ERROR: Run `composer install` or `composer update -W` to install the dependencies',
+			' and generate the autoload files before running the unit tests.', \PHP_EOL;
 		exit( 1 );
 	}
 }


### PR DESCRIPTION
### Integration tests: update the bootstrap for compatibility with WP 5.9

As of WP 5.9, the PHPUnit Polyfills are also used by WordPress itself and WordPress will try to autoload the Autoloader for the Polyfills.

This will work fine if WordPress is fully installed, but for a partial install, like provided via the WP-CLI `scaffold` command, this can be problematic.
Similarly, if the PHPUnit Polyfills are available, but in a different location than expected by WP Core, again, this can be problematic.

As the PHPUnit Polyfills is also a requirement of WP Test Utils, we can get prevent any issues with this by loading the autoloader ahead of running the WordPress test bootstrap file.

### Integration tests TestCase: double the class for full compat with all supported WP versions

With the introduction of the PHPUnit Polyfills in WP 5.9 and the backport of the availability of the PHPUnit Polyfills + the snake case test wrappers to WP 5.2 - 5.8, integration tests for plugins/themes which test against WP 5.2 - 5.9 (and higher) can start using modern PHPUnit assertions and expectations, as well as switch over to using the `snake_case` fixture method names.

There is a caveat to this however:
* Plugins/themes which test against older WP versions (< 5.2) don't have access to either the polyfills or the snake_case fixture method wrappers.
* Same goes for tests being run against the current WP `latest`, which is the last 5.8.x release (5.8.1), which doesn't yet include the changes.
* Same goes for tests being run against all WP 5.2 - 5.8 minors which were released before today.

This commit:
* Introduces the snake_case fixture method wrappers to the WP integration test `TestCase`.
* Introduces a second `TestCase` for the WP integration tests.
    The original `TestCase` is suitable for use for older WP versions which don't include the test changes from WP 5.9.
    The new `TestCase` is suitable for use with WP 5.9 and WP versions which *do* include the test changes from WP 5.9.
    The new `TestCase` does not include the Polyfills as those will be inherited from WordPress.
* Both these test cases have exactly the same name `Yoast\WPTestUtils\WPIntegration\TestCase` so concrete test classes can extend this class safely.
    Because of this, this class will no longer be loaded via the Composer classmap though.
    Instead, the custom Autoloader, which was already in place for the WP Integration tests, has been adjusted to handle loading the correct version of the class depending on whether or not the WP version against which the tests are being run contains the (backported) changes from WP 5.9 or not.

Includes minor tweak to the PHPCS config to allow for the duplicate class.

Fixes #14
