### PR TITLE
README: update for version 1.0.0 and WP 5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@ This library contains a set of utilities for running automated tests for WordPre
 * [Installation](#installation)
 * [Features](#features)
     - [Utilities for running tests using BrainMonkey](#utilities-for-running-tests-using-brainmonkey)
+        - [Basic `TestCase` for use with BrainMonkey](#basic-testcase-for-use-with-brainmonkey)
+        - [Yoast TestCase for use with BrainMonkey](#yoast-testcase-for-use-with-brainmonkey)
+        - [Bootstrap file for use with BrainMonkey](#bootstrap-file-for-use-with-brainmonkey)
     - [Utilities for running integration tests with WordPress](#utilities-for-running-integration-tests-with-wordpress)
+        - [What these utilities solve](#what-these-utilities-solve)
+        - [Basic `TestCase` for WordPress integration tests](#basic-testcase-for-wordpress-integration-tests)
+        - [Bootstrap utility functions and custom autoloader](#bootstrap-utility-functions-and-custom-autoloader)
     - [Test Helpers](#test-helpers)
+        - [`Yoast\WPTestUtils\Helpers\EscapeOutputHelper` trait](#yoastwptestutilshelpersescapeoutputhelper-trait)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -25,9 +32,10 @@ Requirements
 * PHP 5.6 or higher.
 
 The following packages will be automatically required via Composer:
-* [PHPUnit Polyfills] 1.0.0 or higher.
+* [PHPUnit Polyfills] 1.0.1 or higher.
 * [PHPUnit] 5.7 - 9.x.
 * [BrainMonkey] 2.6.0 or higher.
+
 
 Installation
 -------------------------------------------
@@ -55,13 +63,13 @@ Features of this `TestCase`:
 1. Cross-version compatibility with PHPUnit 5.7 - 9.x via the [PHPUnit Polyfills] package.
 2. The BrainMonkey and Mockery set up and tear down is already handled.
 3. Tests using Mockery expectations will not be marked as "risky", even when there are no assertions.
-4. Makes alternative implementations of the BrainMonkey native [`stubTranslationFunctions()`](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-translation-functions) and [`stubEscapeFunctions()`](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-escaping-functions) functions available.
-    The BrainMonkey native functions create stubs which will apply basic HTML escaping if the stubbed function is an escaping function, like `esc_html__()`.
-    The alternative implementations of these functions will create stubs which will return the original value without change. This makes creating tests easier as the `$expected` value does not need to account for the HTML escaping.
+4. Makes alternative implementations of the BrainMonkey native [`stubTranslationFunctions()`](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-translation-functions) and [`stubEscapeFunctions()`](https://giuseppe-mazzapica.gitbook.io/brain-monkey/functions-testing-tools/function-stubs#pre-defined-stubs-for-escaping-functions) functions available.<br/>
+    The BrainMonkey native functions create stubs which will apply basic HTML escaping if the stubbed function is an escaping function, like `esc_html__()`.<br/>
+    The alternative implementations of these functions will create stubs which will return the original value without change. This makes creating tests easier as the `$expected` value does not need to account for the HTML escaping.<br/>
     _Note: the alternative implementation should be used selectively._
 5. Helper functions for setting expectations for generated output.
 
-Implementation example:
+**_Implementation example:_**
 ```php
 <?php
 namespace PackageName\Tests;
@@ -78,7 +86,7 @@ class FooTest extends TestCase {
         // Your own additional tear down.
         parent::tear_down();
     }
-    
+
     public function testAFunctionContainingStringTranslating() {
         $this->stubTranslationFunctions(); // No HTML escaping will be applied.
         // Or:
@@ -104,22 +112,23 @@ Features of this TestCase:
 1. All the benefits of the basic TestCase as outlined above.
 2. By default, the following WordPress functions will be stubbed, in addition to [the stubs already provided by BrainMonkey](https://giuseppe-mazzapica.gitbook.io/brain-monkey/wordpress-specific-tools/wordpress-tools):
 
-    | WP function                                            | Stub will return                                                                      | Notes                                                                    |
-    |--------------------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-    | `get_bloginfo( 'charset' )`                            | `'UTF-8'`                                                                             |                                                                          |
-    | `get_bloginfo( 'language' )`                           | `'English'`                                                                           |                                                                          |
+    | WP function                                            | Stub will return                                                                      |
+    |--------------------------------------------------------|---------------------------------------------------------------------------------------|
+    | `get_bloginfo( 'charset' )`                            | `'UTF-8'`                                                                             |
+    | `get_bloginfo( 'language' )`                           | `'English'`                                                                           |
     | `is_multisite()`                                       | Value of the `WP_TESTS_MULTISITE` PHP constant as a boolean (if defined), otherwise `false` |                                                                          |
-    | `mysql2date( $format, $date )`                         | `$date` (original value)                                                              |                                                                          |
-    | `number_format_i18n( $number, $decimals )`             | `$number` (original value)                                                            |                                                                          |
-    | `sanitize_text_field( $str )`                          | `$str` (original value)                                                               |                                                                          |
-    | `site_url()`                                           | `'https://www.example.org'`                                                           |                                                                          |
-    | `wp_kses_post( $data )`                                | `$data` (original value)                                                              |                                                                          |
-    | `wp_parse_args( $args, $defaults )`                    | `array_merge( $defaults, $args )`                                                     |                                                                          |
-    | `wp_strip_all_tags( $string, $remove_breaks = false )` | emulated return value as per the WP native functionality, might miss some edge cases  |                                                                          |
-    | `wp_slash( $value )`                                   | `$value` (original value)                                                             |                                                                          |
-    | `wp_unslash( $value )`                                 | `stripslashes( $value )` if `$value` is a string, otherwise `$value` (original value) |                                                                          |
+    | `mysql2date( $format, $date )`                         | `$date` (original value)                                                              |
+    | `number_format_i18n( $number, $decimals )`             | `$number` (original value)                                                            |
+    | `sanitize_text_field( $str )`                          | `$str` (original value)                                                               |
+    | `site_url()`                                           | `'https://www.example.org'`                                                           |
+    | `wp_kses_post( $data )`                                | `$data` (original value)                                                              |
+    | `wp_parse_args( $args, $defaults )`                    | `array_merge( $defaults, $args )`                                                     |
+    | `wp_strip_all_tags( $string, $remove_breaks = false )` | Emulated return value as per the WP native functionality, might miss some edge cases  |
+    | `wp_slash( $value )`                                   | `$value` (original value)                                                             |
+    | `wp_unslash( $value )`                                 | `stripslashes( $value )` if `$value` is a string, otherwise `$value` (original value) |
 
-Implementation example:
+
+**_Implementation example:_**
 ```php
 <?php
 namespace PackageName\Tests;
@@ -131,6 +140,7 @@ class FooTest extends YoastTestCase {
 }
 ```
 
+
 #### Bootstrap file for use with BrainMonkey
 
 Most of the time, using the Composer `vendor/autoload.php` file as your bootstrap file for PHPUnit will be sufficient.
@@ -138,16 +148,16 @@ Most of the time, using the Composer `vendor/autoload.php` file as your bootstra
 However, in the context of testing WordPress plugins and themes, it can be useful to have access to certain constants which WordPress natively declares.
 
 The bootstrap file for use with BrainMonkey will make sure that the following constants are defined:
-|                   |                     |                    |
-|-------------------|---------------------|--------------------|
-| `ABSPATH`         | `MINUTE_IN_SECONDS` | `HOUR_IN_SECONDS`  |
-| `DAY_IN_SECONDS`  | `WEEK_IN_SECONDS`   | `MONTH_IN_SECONDS` |
-| `YEAR_IN_SECONDS` | `DB_HOST`           | `DB_NAME`          |
-| `DB_USER`         | `DB_PASSWORD`       |                    |
+|                   |                     |                   |                  |
+|-------------------|---------------------|-------------------|------------------|
+| `ABSPATH`         | `MINUTE_IN_SECONDS` | `HOUR_IN_SECONDS` | `DAY_IN_SECONDS` |
+| `WEEK_IN_SECONDS` | `MONTH_IN_SECONDS`  | `YEAR_IN_SECONDS` |                  |
+| `DB_HOST`         | `DB_NAME`           | `DB_USER`         | `DB_PASSWORD`    |
+
 
 In addition to that, it will clear the PHP Opcache before running the tests.
 
-Implementation example:
+**_Implementation example:_**
 ```php
 <?php
 // File: tests/bootstrap.php
@@ -160,15 +170,47 @@ To tell PHPUnit to use this bootstrap file, use `--bootstrap tests/bootstrap.php
 
 ### Utilities for running integration tests with WordPress
 
+#### What these utilities solve
+
+1. **Running tests using the PHPUnit native [mocking functionality](https://phpunit.readthedocs.io/en/stable/test-doubles.html) against PHP 8.0, while testing against WordPress 5.6 - 5.8.**
+
+    WP 5.6 is the first WordPress version with (beta) support for PHP 8.0.
+
+    In most cases, for WordPress integration tests, the WordPress Core native test bootstrap file will be loaded to set up the test environment, including the database.<br/>
+    However, WordPress, until WP 5.9, had a hard limit on PHPUnit 7.5 max, while PHPUnit 9.3 is the first PHPUnit version which has full PHP 8.0 support, making testing on PHP 8.0 with WP 5.6 - 5.8 problematic.
+
+    In WordPress 5.6 to 5.8, this problem was solved by adding copies of select PHPUnit 9.x files to the WordPress test suite and loading those files when running PHPUnit 7.x on PHP 8.0, instead of the PHPUnit 7.x native ones.<br/>
+    The way this solution was implemented, however, is not portable to plugins/themes.
+
+    WP Test Utils solves this problem for plugin and theme integration tests via the WP Integration test bootstrap utilities.
+
+2. **WP 5.9 makes significant changes to the WP Core test suite**
+
+    As of WP 5.9, the [PHPUnit Polyfills] package has become a requirement, test fixtures now need to be declared in `snake_case` etc.<br/>
+    For full details about what has changed in the WP Core test suite in WP 5.9, please see the [Make Core dev-note about these changes](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/).
+
+    These WP Core test changes have been partially backported and once a plugin/theme integration test suite has been upgraded for the WP 5.9 changes, it can be safely run against the WP `trunk` and `5.x` (`5.2` - `5.8`) branches.
+
+    There is a caveat to this however:
+    - Plugins/themes which test against older WP versions (< `5.2`) don't have access to either the polyfills or the snake_case fixture method wrappers.
+    - Same goes for tests being run against WP `latest` until WordPress `5.8.2` has been tagged.
+    - Same goes for tests being run against specific WP 5.2 - 5.8 minors released before the backports were committed, i.e. WP `5.2.0` - `5.2.12`, WP `5.3.0` - `5.3.9`, WP `5.4.0` - `5.4.7`, WP `5.5.0` - `5.5.6`, WP `5.6.0` - `5.6.5`, WP `5.7.0` - `5.7.3` and WP `5.8.0` - `5.8.1`.
+
+    WP Test Utils solves this problem by having two version of the `TestCase` offered and loading the correct one depending on the WP version the tests are being run against.<br/>
+    The loading of the correct `TestCase` is, again, handled via the WP Integration test bootstrap utilities.
+
+
 #### Basic `TestCase` for WordPress integration tests
 
 Features of this `TestCase`:
 1. Extends the WP native base test case `WP_UnitTestCase`, making all the WP Core test utilities available to your integration test classes.
-2. Cross-version compatibility with PHPUnit 5.7 - 9.x via the [PHPUnit Polyfills] package.
-    _Note: WordPress Core limit tests to running on PHPUnit 7.5 max. However, using these polyfills you can already start using the up-to-date PHPUnit 9.x syntax, even though the tests don't use PHPUnit 9 yet._
-3. Helper functions for setting expectations for generated output.
+2. Cross-version compatibility with PHPUnit 5.7 - 9.x via the [PHPUnit Polyfills] package.<br/>
+    _Using these polyfills you can use the up-to-date PHPUnit 9.x syntax, independently of the WP version against which the tests are being run._<br/>
+    _Note: WordPress Core in WP < 5.9 still limits integration tests to running on PHPUnit 7.5 max. As of WP 5.9, tests can run cross-version on PHPUnit 5.7 - 9.x._
+3. Ability to use the fixture method `snake_case` wrappers independently of the WP version against which the tests are being run.
+4. Helper functions for setting expectations for generated output.
 
-Implementation example:
+**_Implementation example:_**
 ```php
 <?php
 namespace PackageName\Tests;
@@ -176,41 +218,43 @@ namespace PackageName\Tests;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 class FooTest extends TestCase {
-    protected function setUp() {
-        parent::setUp();
+    protected function set_up() {
+        parent::set_up();
         // Your own additional setup.
     }
 }
 ```
 
+
 #### Bootstrap utility functions and custom autoloader
 
-In most cases, for WordPress integration tests, the WordPress Core native test bootstrap file will be loaded to set up the test environment, including the database.
-However, WordPress has a hard limit on PHPUnit 7.5 max, while PHPUnit 9.3 is the first PHPUnit version which has full PHP 8.0 support, making testing on PHP 8.0 problematic.
+The WP Integration bootstrap utilities consist of:
+* A `bootstrap-functions.php` file with utility functions for use in the test `bootstrap` file for the integration tests for a plugin or theme.
+* A custom autoloader which will selectively autoload the WP copies of the PHPUnit 9 native MockBuilder files for PHPUnit < 9 when run on PHP 8 and which will handle loading the correct `TestCase` version depending on the WP version tests are run against.
 
-In WordPress Core, this problem has been solved by adding copies of select PHPUnit 9.x files to the WordPress test suite and loading those files when running PHPUnit 7.x on PHP 8.0 instead of the PHPUnit 7 native ones.
-The way this solution has been implemented, however, is not portable to plugins.
-
-In comes WP Test Utils... which offers:
-* A `bootstrap-functions.php` file with utility functions for use in the test `bootstrap` file for the integration tests for a plugin.
-* A custom autoloader which will selectively autoload the WP copies of the PHPUnit 9 native MockBuilder files for PHPUnit < 9 when run on PHP 8 to get round the use of the new reserved keyword `match` as was used in older versions of these files.
-
-The functionality within these files presumes three things:
+The bootstrap utilies presume two things:
 1. This package is installed as a dependency of a plugin via Composer and will be in the `vendor/yoast/wp-test-utils/` directory.
-2. WordPress itself is available in its entirety, including the `includes` subdirectory of the WP native `tests/phpunit` directory.
-3. The location of the test files from the WordPress installation is known.
+2. The `includes` subdirectory of the WordPress Core native `tests/phpunit` directory is available.
 
-The location of the test files from the WordPress install can be made known in the following ways:
-1. Either set a `WP_TESTS_DIR` environment variable to the path to the WordPress Core `./tests/phpunit` directory; or a directory containing the `includes` subdirectory from the WordPress Core `./tests/phpunit` directory, such as created by the WP CLI `scaffold` command.
-2. Or set the `WP_DEVELOP_DIR` environment variable to the path to the WordPress Core root directory from a git/svn check-out.
+The location of the `includes` directory containing the test framework files from WordPress Core will be determined in the following manner:
+1. Check if a `WP_TESTS_DIR` environment variable is available pointing to the WordPress Core `./tests/phpunit` directory; or a directory containing a copy of the `includes` subdirectory from the WordPress Core `./tests/phpunit` directory.
+2. If not, check to see if a `WP_DEVELOP_DIR` environment variable is available which points to a path containing the WordPress Core root directory from a git/svn check-out.
+3. If not, it is checked if the plugin/theme is installed within WordPress itself in a `src/wp-content/plugins/plugin-name` or `src/wp-content/themes/theme-name` directory, with this package in the `src/wp-content/plugins/plugin-name/vendor/yoast/wp-test-utils` directory.
+4. As a last resort, a check is done for the typical WP-CLI `scaffold` command setup, where the `includes` subdirectory from the WordPress Core `tests/phpunit` directory has been placed in the system temp directory.
 
-These environment variables can be set on the OS level or from within a `phpunit.xml[.dist]` file.
+These checks are in line with typical integration test setups in the context of WordPress.
 
-If neither of the environment variables is available, the plugin is presumed to be installed within WordPress itself in a `src/wp-content/plugins/plugin-name` directory, with this package in the `src/wp-content/plugins/plugin-name/vendor/yoast/wp-test-utils` directory.
+:point_right: The above mentioned environment variables can be set on the OS level or from within a `phpunit.xml[.dist]` file.
 
-This is in line with a typical integration test setup in the context of WordPress.
 
-Implementation example for how this functionality would typically be used in the bootstrap file of a WordPress plugin:
+##### Using the bootstrap utilities
+
+There are two prevelant patterns for wiring in a plugin/theme to WordPress in an integration test bootstrap file. The bootstrap utilities can be used with both.
+
+To implement use of the bootstrap utilities, use whichever pattern matches your current bootstrap file most closely.
+
+**_Implementation example 1:_**
+
 ```php
 use Yoast\WPTestUtils\WPIntegration;
 
@@ -225,14 +269,43 @@ $GLOBALS['wp_tests_options'] = [
 require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
 /*
- * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
+ * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
+ * and the custom autoloader for the TestCase and the mock object classes.
  */
 WPIntegration\bootstrap_it();
 
 if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/plugin-name/main-file.php' ) === false ) {
-    echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
+    echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The integration test suite won\'t be able to run without it.', PHP_EOL;
     exit( 1 );
 }
+```
+
+**_Implementation example 2:_**
+```php
+use Yoast\WPTestUtils\WPIntegration;
+
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
+
+// Get access to tests_add_filter() function.
+require_once $_tests_dir . 'includes/functions.php';
+
+/**
+ * Callback to manually load the plugin
+ */
+function _manually_load_plugin() {
+    require_once __DIR__ . '/relative/path/to/main-file.php';
+}
+
+// Add plugin to active mu-plugins to make sure it gets loaded.
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+/*
+ * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
+ * and the custom autoloader for the TestCase and the mock object classes.
+ */
+WPIntegration\bootstrap_it();
 ```
 
 
@@ -242,7 +315,7 @@ if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/plugin-name/
 
 PHPUnit natively contains the `expectOutputString()` (exact string) and the `expectOutputRegex()` (regex match) method, but sometimes you need a little more flexibility.
 
-A typical pattern used is to check whether the output generated contains certain substrings.
+A typical pattern used, is to check whether the output generated contains certain substrings.
 And a typical reason for mismatched output versus expectation, is a mismatch in line endings.
 
 This `EscapeOutputHelper` trait adds the following functions to solve these issues:
@@ -251,7 +324,7 @@ This `EscapeOutputHelper` trait adds the following functions to solve these issu
     If a test needs to check that the generated output contains multiple different substrings, refactor the test to use a data provider feeding the test one substring at a time.
 * `normalizeLineEndings( $output )` which is intended to be used in conjunction with the PHPUnit native `setOutputCallback()` method to normalize line endings in the actual output before comparing output expectations with the actual output.
 
-:point_right: This trait is automatically available to test classes based on the BrainMonkey or WPIntegration `TestCase`s as included in this package.
+:point_right: This trait is automatically available to test classes based on the BrainMonkey or WPIntegration `TestCase`s as included in WP Test Utils.
 
 
 Contributing


### PR DESCRIPTION
* Improve readability.
* Update for changes includes in v 1.0.0.
* Add more detailed information about why this library is useful and what it solves, including information about the test changes in WP 5.9.
* Add second implementation example for integration test bootstraps.
* Minor other tweaks.