### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -26,7 +26,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,12 +40,12 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies for PHP < 8.2
         if: ${{ matrix.php < 8.2 }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # For PHP 8.1 and above, we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies for PHP >= 8.2
         if: ${{ matrix.php >= 8.2 }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2