### PR TITLE
Composer: update keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name" : "yoast/wp-test-utils",
     "description" : "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
-    "keywords" : [ "wordpress", "unit-testing", "integration-testing", "brainmonkey", "phpunit" ],
+    "keywords" : [ "wordpress", "unit-testing", "integration-testing", "brainmonkey", "phpunit", "testing" ],
     "license" : "BSD-3-Clause",
     "homepage": "https://github.com/Yoast/wp-test-utils/",
     "authors": [


### PR DESCRIPTION
Since Composer 2.4.0, Composer will prompt users if they are sure they want to install something as `require` instead of `require-dev` if the package contains certain "dev" related keyword, like `testing`.

This adds the keyword to this package to help users add the package in the most appropriate place.

Refs:
* https://getcomposer.org/doc/04-schema.md#keywords
* https://github.com/composer/composer/pull/10960