### PR TITLE
BrainMonkey/TestCase: add new `makeDouble[s]ForUnavailableClass[es]()` functions

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -109,10 +109,16 @@
 
 	<!-- Allow for camelCase method and variable names to be more in line with PHPUnit and BrainMonkey. -->
 	<rule ref="WordPress.NamingConventions.ValidFunctionName">
+		<exclude-pattern>/src/BrainMonkey/bootstrap\.php$</exclude-pattern>
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- This class is not a test double for the tests, but a _feature_ of this package. -->
+	<rule ref="Yoast.Files.TestDoubles">
+		<exclude-pattern>/src/BrainMonkey/Doubles/DummyTestDouble\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Ignore word count for object names in tests. -->

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This library contains a set of utilities for running automated tests for WordPre
         - [Basic `TestCase` for use with BrainMonkey](#basic-testcase-for-use-with-brainmonkey)
         - [Yoast TestCase for use with BrainMonkey](#yoast-testcase-for-use-with-brainmonkey)
         - [Bootstrap file for use with BrainMonkey](#bootstrap-file-for-use-with-brainmonkey)
+        - [Helpers to create test doubles for unavailable classes](#helpers-to-create-test-doubles-for-unavailable-classes)
     - [Utilities for running integration tests with WordPress](#utilities-for-running-integration-tests-with-wordpress)
         - [What these utilities solve](#what-these-utilities-solve)
         - [Basic `TestCase` for WordPress integration tests](#basic-testcase-for-wordpress-integration-tests)
@@ -67,7 +68,8 @@ Features of this `TestCase`:
     The BrainMonkey native functions create stubs which will apply basic HTML escaping if the stubbed function is an escaping function, like `esc_html__()`.<br/>
     The alternative implementations of these functions will create stubs which will return the original value without change. This makes creating tests easier as the `$expected` value does not need to account for the HTML escaping.<br/>
     _Note: the alternative implementation should be used selectively._
-5. Helper functions for setting expectations for generated output.
+5. Helper functions for [setting expectations for generated output](#yoastwptestutilshelpersescapeoutputhelper-trait).
+6. Helper functions for [creating "dummy" test doubles for unavailable classes](#helpers-to-create-test-doubles-for-unavailable-classes).
 
 **_Implementation example:_**
 ```php
@@ -166,6 +168,76 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 ```
 
 To tell PHPUnit to use this bootstrap file, use `--bootstrap tests/bootstrap.php` on the command-line or add the `bootstrap="tests/bootstrap.php"` attribute to your `phpunit.xml.dist` file.
+
+
+#### Helpers to create test doubles for unavailable classes
+
+##### Why you may need to create test doubles for unavailable classes
+
+Typically a mock for an unavailable class is created using `Mockery::mock()` or `Mockery::mock( 'Unavailable' )`.
+
+When either the test or the code under test sets a property on such a mock, this will lead to a ["Creation of dynamic properties is deprecated" notice](https://wiki.php.net/rfc/deprecate_dynamic_properties) on PHP >= 8.2, which can cause tests to error out.
+
+If you know for sure the property being set on the mock is a declared property or a property supported via [magic methods](https://www.php.net/oop5.overloading#language.oop5.overloading.members) on the class which is being mocked, the _code under test_ will under normal circumstances never lead to this deprecation notice, but your tests now do.
+
+Primarly this is an issue with Mockery. A [question on how to handle this/to add support for this in Mockery itself](https://github.com/mockery/mockery/issues/1197) is open, but in the mean time a work-around is needed (if you're interested, have a read through the Mockery issue for details about alternative solutions and why those don't work as intended).
+
+##### How to use the functionality
+
+WP Test Utils offers three new utilities to solve this (as of version 1.1.0).
+* `Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses( array $class_names )` for use from within a test bootstrap file.
+* `Yoast\WPTestUtils\BrainMonkey\TestCase::makeDoublesForUnavailableClasses( array $class_names )` and `Yoast\WPTestUtils\BrainMonkey\TestCase::makeDoubleForUnavailableClass( string $class_name )` for use from within a test class.
+
+These methods can be used to create one or more "fake" test double classes on the fly, which allow for setting (dynamic) properties.
+These "fake" test double classes are effectively aliases for `stdClass`.
+
+These methods are solely intended for classes which are unavailable during the test run and have no effect (at all!) on classes which _are_ available during the test run.
+
+For setting expectations on the "fake" test double, use `Mockery::mock( 'FakedClass' )`.
+
+**_Implementation example using the bootstrap function:_**
+
+You can create the "fake" test doubles for a complete test suite in one go in your test bootstrap file like so:
+
+```php
+<?php
+// File: tests/bootstrap.php
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+Yoast\WPTestUtils\BrainMonkey\makeDoublesForUnavailableClasses( [ 'WP_Post', 'wpdb' ] );
+```
+
+**_Implementation example using these functions from within a test class:_**
+
+Alternatively, you can create the "fake" test double(s) last minute in each test class which needs them.
+
+```php
+<?php
+namespace PackageName\Tests;
+
+use Mockery;
+use WP_Post;
+use wpdb;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class FooTest extends TestCase {
+    protected function set_up_before_class() {
+        parent::set_up_before_class();
+        self::makeDoublesForUnavailableClasses( [ WP_Post::class, wpdb::class ] );
+        // or if only one class is needed:
+        self::makeDoubleForUnavailableClass( WP_Post::class );
+    }
+
+    public function testSomethingWhichUsesWpPost() {
+        $wp_post = Mockery::mock( WP_Post::class );
+        $wp_post->post_title = 'my test title';
+        $wp_post->post_type  = 'my_custom_type';
+
+        $this->assertSame( 'expected', \function_under_test( $wp_post ) );
+    }
+}
+```
 
 
 ### Utilities for running integration tests with WordPress

--- a/src/BrainMonkey/Doubles/DummyTestDouble.php
+++ b/src/BrainMonkey/Doubles/DummyTestDouble.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yoast\WPTestUtils\BrainMonkey\Doubles;
+
+use stdClass;
+
+/**
+ * This is a "dummy" test double class for use with Mockery.
+ *
+ * This class allows to mock classes which are unavailable during the test run
+ * and on which properties need to be set, either from within the test or
+ * from within the code under test, by aliasing this class ahead of creating the mock.
+ *
+ * Mocking unavailable classes using an anonymous mock - `Mockery::mock()` or
+ * a mock for a specific named, but unavailable class - `Mockery::mock( 'Unavailable' )` -
+ * worked fine prior to PHP 8.2.
+ * However, PHP 8.2 deprecates the use of dynamic properties, which means that if
+ * either of the above code patterns is used and either the test or the code under
+ * test sets properties on the Mock, tests will throw deprecation notices and,
+ * depending on the value for the PHPUnit `convertDeprecationsToExceptions` configuration
+ * option, tests may show as errored.
+ *
+ * The "go to" pattern to solve this is to let the mock extend `stdClass`, but
+ * as `stdClass` always exists, the class will then identify as an instance of `stdClass`
+ * and no longer as an instance of the "Unavailable" class, which causes problems
+ * with code using type declarations of calls to `instanceof`.
+ *
+ * The other alternative would be to used `Mockery::namedMock()` or an alias mock, but
+ * both of these require each test using these to run in a separate process, which
+ * makes debugging of failing tests more complicated as well as making the test suite
+ * slower.
+ *
+ * Note: aliasing `stdClass` directly is not allowed in PHP, which is why this
+ * dummy test double class is put in place.
+ *
+ * @link https://github.com/mockery/mockery/issues/1197
+ */
+class DummyTestDouble extends stdClass {}

--- a/src/BrainMonkey/bootstrap.php
+++ b/src/BrainMonkey/bootstrap.php
@@ -32,3 +32,17 @@ namespace Yoast\WPTestUtils\BrainMonkey;
 if ( \function_exists( 'opcache_reset' ) ) {
 	\opcache_reset();
 }
+
+/**
+ * On the fly create multiple "fake" test double classes which allow for setting
+ * (dynamic) properties on them.
+ *
+ * @see TestCase::makeDoubleForUnavailableClass()
+ *
+ * @param string[] $class_names List of class names to be "faked".
+ *
+ * @return void
+ */
+function makeDoublesForUnavailableClasses( array $class_names ) {
+	TestCase::makeDoublesForUnavailableClasses( $class_names );
+}

--- a/tests/BrainMonkey/Fixtures/AnotherAvailableClass.php
+++ b/tests/BrainMonkey/Fixtures/AnotherAvailableClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures;
+
+/**
+ * Fixture to test the TestCase::makeDoubleForUnavailableClass() method.
+ */
+class AnotherAvailableClass {}

--- a/tests/BrainMonkey/Fixtures/AvailableClass.php
+++ b/tests/BrainMonkey/Fixtures/AvailableClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures;
+
+/**
+ * Fixture to test the TestCase::makeDoubleForUnavailableClass() method.
+ */
+class AvailableClass {}

--- a/tests/BrainMonkey/TestCaseTest.php
+++ b/tests/BrainMonkey/TestCaseTest.php
@@ -3,7 +3,13 @@
 namespace Yoast\WPTestUtils\Tests\BrainMonkey;
 
 use Brain\Monkey\Functions;
+use Mockery;
+use ReflectionClass;
+use UnavailableClassB;
+use Yoast\WPTestUtils\BrainMonkey\Doubles\DummyTestDouble;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures\AnotherAvailableClass;
+use Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures\AvailableClass;
 
 /**
  * Basic test for the BrainMonkey TestCase setup.
@@ -96,5 +102,171 @@ class TestCaseTest extends TestCase {
 			'some <div>test</div>',
 			\esc_html( 'some <div>test</div>' )
 		);
+	}
+
+	/**
+	 * Verify that creating a test double aliases for an unavailable class works as expected.
+	 *
+	 * @return void
+	 */
+	public function testMakeDoubleForUnavailableClass() {
+		$this->assertFalse(
+			\class_exists( 'UnavailableClassA' ),
+			'Class UnavailableClassA appears to already exist'
+		);
+
+		$this->makeDoubleForUnavailableClass( 'UnavailableClassA' );
+
+		$this->assertTrue(
+			\class_exists( 'UnavailableClassA' ),
+			'Class UnavailableClassA still doesn\'t appear to exist'
+		);
+
+		$reflection_class = new ReflectionClass( 'UnavailableClassA' );
+		$this->assertSame(
+			DummyTestDouble::class,
+			$reflection_class->getName(),
+			'Class UnavailableClassA is not an alias for the DummyTestDouble class'
+		);
+	}
+
+	/**
+	 * Verify that properties can be set on a test double created using the `makeDoubleForUnavailableClass()` method.
+	 *
+	 * @return void
+	 */
+	public function testDoubleForUnavailableClassAllowsSettingProperties() {
+		$this->assertFalse(
+			\class_exists( UnavailableClassB::class ),
+			'Class UnavailableClassB appears to already exist'
+		);
+
+		static::makeDoubleForUnavailableClass( UnavailableClassB::class );
+
+		$unavailable_class           = new UnavailableClassB();
+		$unavailable_class->property = 10;
+
+		$this->assertTrue(
+			\property_exists( $unavailable_class, 'property' ),
+			'Property does not exist on test double'
+		);
+		$this->assertSame(
+			10,
+			$unavailable_class->property,
+			'Property value on test double does not match expected value'
+		);
+	}
+
+	/**
+	 * Verify that properties can be set on a mock of a test double, which was created
+	 * using the `makeDoubleForUnavailableClass()` method.
+	 *
+	 * @return void
+	 */
+	public function testDoubleForUnavailableClassAllowsSettingPropertiesWhenMocked() {
+		$this->assertFalse(
+			\class_exists( 'UnavailableClassC' ),
+			'Class UnavailableClassC appears to already exist'
+		);
+
+		self::makeDoubleForUnavailableClass( 'UnavailableClassC' );
+
+		$mock_of_unavailable_class           = Mockery::mock( 'UnavailableClassC' );
+		$mock_of_unavailable_class->property = 'test';
+
+		$this->assertTrue(
+			\property_exists( $mock_of_unavailable_class, 'property' ),
+			'Property does not exist on mocked test double'
+		);
+		$this->assertSame(
+			'test',
+			$mock_of_unavailable_class->property,
+			'Property value on mocked test double does not match expected value'
+		);
+	}
+
+	/**
+	 * Verify that no errors or warnings are thrown when a test double is requested for a class
+	 * which already exists, but wasn't loaded prior to the `makeDoubleForUnavailableClass()` function being called.
+	 *
+	 * @return void
+	 */
+	public function testMakeDoubleForAvailableClassNotYetInMemoryDoesNotCreateDouble() {
+		$this->assertFalse(
+			\class_exists( AvailableClass::class, false ), // Don't autoload this class!
+			'Class Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures\AvailableClass already loaded, test is invalid'
+		);
+
+		$this->makeDoubleForUnavailableClass( AvailableClass::class );
+
+		$reflection_class = new ReflectionClass( AvailableClass::class );
+		$this->assertSame(
+			AvailableClass::class,
+			$reflection_class->getName(),
+			'The class does not point to the original, available class'
+		);
+	}
+
+	/**
+	 * Verify that no errors or warnings are thrown when a test double is requested for a class
+	 * which already exists and was already loaded prior to the `makeDoubleForUnavailableClass()` function being called.
+	 *
+	 * @return void
+	 */
+	public function testMakeDoubleForAvailableClassAlreadyInMemoryDoesNotCreateDouble() {
+		// Don't load via autoloader.
+		require_once __DIR__ . '/Fixtures/AnotherAvailableClass.php';
+
+		$this->assertTrue(
+			\class_exists( AnotherAvailableClass::class ),
+			'Class Yoast\WPTestUtils\Tests\BrainMonkey\Fixtures\AnotherAvailableClass doesn\'t exist prior to this test'
+		);
+
+		$this->makeDoubleForUnavailableClass( AnotherAvailableClass::class );
+
+		$reflection_class = new ReflectionClass( AnotherAvailableClass::class );
+		$this->assertSame(
+			AnotherAvailableClass::class,
+			$reflection_class->getName(),
+			'The class does not point to the original, available class'
+		);
+	}
+
+	/**
+	 * Verify that creating multiple test double aliases in one go works as expected.
+	 *
+	 * This test also safeguards that the functionality also works with namespaced class names.
+	 *
+	 * @return void
+	 */
+	public function testMakeDoublesForUnavailableClasses() {
+		$classes = [
+			'UnavailableClassX',
+			'My\\Namespace\\UnavailableClassY',
+			'Other\\UnavailableClassZ',
+		];
+
+		foreach ( $classes as $class_name ) {
+			$this->assertFalse(
+				\class_exists( $class_name ),
+				"Class $class_name appears to already exist"
+			);
+		}
+
+		self::makeDoublesForUnavailableClasses( $classes );
+
+		foreach ( $classes as $class_name ) {
+			$this->assertTrue(
+				\class_exists( $class_name ),
+				"Class $class_name still doesn't appear to exist"
+			);
+
+			$reflection_class = new ReflectionClass( $class_name );
+			$this->assertSame(
+				DummyTestDouble::class,
+				$reflection_class->getName(),
+				"Class $class_name is not an alias for the DummyTestDouble class"
+			);
+		}
 	}
 }


### PR DESCRIPTION
These methods allow for on the fly creation of test doubles which allow for dynamic properties, which allows for bypassing the PHP 8.2 dynamic property deprecation notice when the _real_ class has these properties declared, but a mock is used in the tests.

See the README docs + https://github.com/mockery/mockery/issues/1197 for additional information.

Includes:
* Tests to cover the new functionality.
* Documentation in the README file.