### PR TITLE
Dependabot: add reviewer config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       prefix: "GH Actions:"
     labels:
       - "yoastcs/qa"
+    reviewers:
+      - "jrfnl"
 
   # Maintain dependencies for Composer.
   - package-ecosystem: "composer"
@@ -27,3 +29,5 @@ updates:
       prefix: "Composer:"
     labels:
       - "yoastcs/qa"
+    reviewers:
+      - "jrfnl"


### PR DESCRIPTION
The Dependabot PRs can have a tendency to stay open for a long time, while for the GH Actions and Composer dependency related ones I keep an eye on all used action runner releases anyway.

However, I don't "watch" all Yoast repos, so adding this configuration will ensure that I get notified about Dependabot PRs for this repo (and can merge it if appropriate or close it otherwise).