### PR TITLE
BrainMonkey/YoastTestCase: rename parameters for mocked functions

### DIFF
--- a/src/BrainMonkey/YoastTestCase.php
+++ b/src/BrainMonkey/YoastTestCase.php
@@ -51,15 +51,15 @@ abstract class YoastTestCase extends TestCase {
 				'wp_parse_args'        => static function ( $settings, $defaults ) {
 					return \array_merge( $defaults, $settings );
 				},
-				'wp_strip_all_tags'    => static function( $string, $remove_breaks = false ) {
-					$string = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
-					$string = \strip_tags( $string );
+				'wp_strip_all_tags'    => static function( $text, $remove_breaks = false ) {
+					$text = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );
+					$text = \strip_tags( $text );
 
 					if ( $remove_breaks ) {
-						$string = \preg_replace( '/[\r\n\t ]+/', ' ', $string );
+						$text = \preg_replace( '/[\r\n\t ]+/', ' ', $text );
 					}
 
-					return \trim( $string );
+					return \trim( $text );
 				},
 				'wp_slash'             => null,
 				'wp_unslash'           => static function( $value ) {

--- a/src/BrainMonkey/YoastTestCase.php
+++ b/src/BrainMonkey/YoastTestCase.php
@@ -48,8 +48,8 @@ abstract class YoastTestCase extends TestCase {
 				'sanitize_text_field'  => null,
 				'site_url'             => 'https://www.example.org',
 				'wp_kses_post'         => null,
-				'wp_parse_args'        => static function ( $settings, $defaults ) {
-					return \array_merge( $defaults, $settings );
+				'wp_parse_args'        => static function ( $args, $defaults ) {
+					return \array_merge( $defaults, $args );
 				},
 				'wp_strip_all_tags'    => static function( $text, $remove_breaks = false ) {
 					$text = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );


### PR DESCRIPTION
### BrainMonkey/YoastTestCase: rename parameter for mocked function

... as WP Core has renamed the parameter as part of the efforts to become compatible with PHP 8.0.

Ref: WordPress/wordpress-develop@51fae8b

### BrainMonkey/YoastTestCase: rename parameter for mocked function

... to be in line with the parameter name as used by WP Core for optimal compatibility with PHP 8.0.

Ref: https://developer.wordpress.org/reference/functions/wp_parse_args/