### PR TITLE
Composer/PHPCS: update for YoastCS 2.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.6-"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"


### PR DESCRIPTION
Follow up on PR #52.

YoastCS 2.3.1 updated the default `testVersion` to PHP `7.2-`, while this package still supports PHP 5.6.