### PR TITLE
Composer: normalize the file and add script descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,77 +1,84 @@
 {
-    "name" : "yoast/wp-test-utils",
-    "description" : "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
-    "keywords" : [ "wordpress", "unit-testing", "integration-testing", "brainmonkey", "phpunit", "testing" ],
-    "license" : "BSD-3-Clause",
-    "homepage": "https://github.com/Yoast/wp-test-utils/",
-    "authors": [
-        {
-            "name": "Team Yoast",
-            "email": "support@yoast.com",
-            "homepage": "https://yoast.com"
-        },
-        {
-            "name" : "Contributors",
-            "homepage" : "https://github.com/Yoast/wp-test-utils/graphs/contributors"
-        }
-    ],
-    "support" : {
-        "issues" : "https://github.com/Yoast/wp-test-utils/issues",
-        "source" : "https://github.com/Yoast/wp-test-utils"
-    },
-    "require" : {
-        "php" : ">=5.6",
-        "yoast/phpunit-polyfills": "^1.0.5",
-        "brain/monkey": "^2.6.1"
-    },
-    "require-dev" : {
-        "yoast/yoastcs": "^2.3.1"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "autoload": {
-        "classmap": [
-            "src/"
-        ],
-        "exclude-from-classmap": [
-            "/src/WPIntegration/TestCase.php",
-            "/src/WPIntegration/TestCaseNoPolyfills.php"
-        ]
-    },
-    "autoload-dev" : {
-        "psr-4": {
-            "Yoast\\WPTestUtils\\Tests\\": "tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-main": "1.x-dev",
-            "dev-develop": "1.x-dev"
-        }
-    },
-    "scripts" : {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
-        ],
-        "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.6-"
-        ],
-        "fix-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ],
-        "coverage-local": [
-            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
-        ]
-    }
+	"name": "yoast/wp-test-utils",
+	"description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+	"license": "BSD-3-Clause",
+	"keywords": [
+		"wordpress",
+		"unit-testing",
+		"integration-testing",
+		"brainmonkey",
+		"phpunit",
+		"testing"
+	],
+	"authors": [
+		{
+			"name": "Team Yoast",
+			"email": "support@yoast.com",
+			"homepage": "https://yoast.com"
+		},
+		{
+			"name": "Contributors",
+			"homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+		}
+	],
+	"homepage": "https://github.com/Yoast/wp-test-utils/",
+	"support": {
+		"issues": "https://github.com/Yoast/wp-test-utils/issues",
+		"source": "https://github.com/Yoast/wp-test-utils"
+	},
+	"require": {
+		"php": ">=5.6",
+		"brain/monkey": "^2.6.1",
+		"yoast/phpunit-polyfills": "^1.0.5"
+	},
+	"require-dev": {
+		"yoast/yoastcs": "^2.3.1"
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"classmap": [
+			"src/"
+		],
+		"exclude-from-classmap": [
+			"/src/WPIntegration/TestCase.php",
+			"/src/WPIntegration/TestCaseNoPolyfills.php"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Yoast\\WPTestUtils\\Tests\\": "tests/"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-develop": "1.x-dev",
+			"dev-main": "1.x-dev"
+		}
+	},
+	"scripts": {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
+		],
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.6-"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		],
+		"coverage-local": [
+			"@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
+		]
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -80,5 +80,13 @@
 		"coverage-local": [
 			"@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage.",
+		"coverage-local": "Run the unit tests with code coverage writing an HTML coverage report to a \"/build/coverage-html\" directory."
 	}
 }


### PR DESCRIPTION
### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-