### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/BrainMonkey/TestCaseTest.php
+++ b/tests/BrainMonkey/TestCaseTest.php
@@ -184,7 +184,7 @@ class TestCaseTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataMakeDoubleForUnavailableClass() {
+	public static function dataMakeDoubleForUnavailableClass() {
 		return [
 			'Global class name'                        => [ 'GlobalClassName' ],
 			'Global class name with leading backslash' => [ '\BackslashedClassName' ],
@@ -220,7 +220,7 @@ class TestCaseTest extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function dataMakeDoubleForUnavailableClassThrowsExceptionWithInvalidName() {
+	public static function dataMakeDoubleForUnavailableClassThrowsExceptionWithInvalidName() {
 		return [
 			'Empty string as class name'                       => [ '' ],
 			'Only backslashes'                                 => [ '\\\\\\' ],

--- a/tests/BrainMonkey/YoastTestCaseTest.php
+++ b/tests/BrainMonkey/YoastTestCaseTest.php
@@ -30,7 +30,7 @@ class YoastTestCaseTest extends YoastTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataStubGetBlogInfo() {
+	public static function dataStubGetBlogInfo() {
 		return [
 			// Explicit cases.
 			'charset' => [
@@ -140,7 +140,7 @@ class YoastTestCaseTest extends YoastTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataStubWpParseArgs() {
+	public static function dataStubWpParseArgs() {
 		return [
 			'two empty arrays' => [
 				'settings' => [],
@@ -221,7 +221,7 @@ class YoastTestCaseTest extends YoastTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataStubWpStripAllTags() {
+	public static function dataStubWpStripAllTags() {
 		return [
 			'Empty string' => [
 				'text'          => '',
@@ -284,7 +284,7 @@ class YoastTestCaseTest extends YoastTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataStubWpSlash() {
+	public static function dataStubWpSlash() {
 		return [
 			'string' => [
 				'input' => "O'Reilly?",
@@ -322,7 +322,7 @@ class YoastTestCaseTest extends YoastTestCase {
 	 *
 	 * @return array
 	 */
-	public function dataStubWpUnslash() {
+	public static function dataStubWpUnslash() {
 		return [
 			'string' => [
 				'input'    => "O\'Reilly\?",

--- a/tests/Helpers/ExpectOutputHelperTest.php
+++ b/tests/Helpers/ExpectOutputHelperTest.php
@@ -125,7 +125,7 @@ jumps over the lazy dog';
 	 *
 	 * @return array
 	 */
-	public function dataMatchingSubstringsMismatchedLineEndings() {
+	public static function dataMatchingSubstringsMismatchedLineEndings() {
 		return [
 			// Actual line ending type.
 			[ "fox\njumps" ],
@@ -233,7 +233,7 @@ jumps over the lazy dog';
 	 *
 	 * @return array
 	 */
-	public function dataNormalizeLineEndings() {
+	public static function dataNormalizeLineEndings() {
 		return [
 			'already-lf'            => [ "foo\n\nbar\n", "foo\n\nbar\n" ],
 			'windows-crlf'          => [ "foo\r\n\r\nbar\r\n", "foo\n\nbar\n" ],


### PR DESCRIPTION
As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.