### PR TITLE
GH Actions/test: PHP 8.3 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,17 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.3']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4']
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
         - php: 5.6
           coverage: true
-        - php: 8.2
+        - php: 8.3
           coverage: true
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     name: "Tests: PHP ${{ matrix.php }}"
 
@@ -47,14 +47,14 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: matrix.php != '8.3'
+        if: matrix.php != '8.4'
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: matrix.php == '8.3'
+        if: matrix.php == '8.4'
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php+


### PR DESCRIPTION
* Builds against PHP 8.3 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.3).
* Add _allowed to fail_ build against PHP 8.4.