### PR TITLE
Composer.json: add link to security policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 	"homepage": "https://github.com/Yoast/wp-test-utils/",
 	"support": {
 		"issues": "https://github.com/Yoast/wp-test-utils/issues",
-		"source": "https://github.com/Yoast/wp-test-utils"
+		"source": "https://github.com/Yoast/wp-test-utils",
+		"security": "https://github.com/Yoast/wp-test-utils/security/policy"
 	},
 	"require": {
 		"php": ">=5.6",


### PR DESCRIPTION
This is a new feature available since Composer 2.6.0, which was released a few weeks ago.

When this key is added, it will also show a link to the security policy on Packagist.

Refs:
* https://github.com/composer/composer/releases/tag/2.6.0
* https://github.com/composer/composer/pull/11271
* https://github.com/composer/packagist/pull/1353