### PR TITLE
Composer/PHPCS: update to YoastCS 3.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
           ini-values: error_reporting=E_ALL, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
 
+      # YoastCS 3.0 has a PHP 7.2 minimum which conflicts with the requirements of this package.
+      - name: 'Composer: remove YoastCS'
+        run: composer remove --dev yoast/yoastcs --no-update --no-interaction
+
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Coding Standard for WP Test Utils" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <description>Check the code of WP Test Utils.</description>
+	<description>Check the code of WP Test Utils.</description>
 
-    <!--
-    #############################################################################
-    COMMAND LINE ARGUMENTS
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-    #############################################################################
-    -->
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
 
-    <file>.</file>
+	<file>.</file>
 
-    <!-- Only check PHP files. -->
-    <arg name="extensions" value="php"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
 
-    <!-- Show progress, show the error codes for each message (source). -->
-    <arg value="ps"/>
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
 
-    <!-- Strip the filepaths down to the relevant bit. -->
-    <arg name="basepath" value="./"/>
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
 
-    <!-- Check up to 8 files simultaneously. -->
-    <arg name="parallel" value="8"/>
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
 
 	<!-- Cache the results between runs. -->
 	<arg name="cache" value="./.cache/phpcs.cache"/>
@@ -41,16 +41,25 @@
 			</property>
 		</properties>
 
-		<!-- Use CamelCaps file names to be more in line with the naming conventions used in PHPUnit. -->
-		<exclude name="Yoast.Files.FileName"/>
+		<!-- Exclude some rules which are irrelevant.
+			 The code in this package is not run in the context of a WordPress plugin. -->
+		<exclude name="WordPress.DB"/>
+		<exclude name="WordPress.Security"/>
+		<exclude name="WordPress.WP"/>
+		<exclude name="Yoast.Yoast.JsonEncodeAlternative"/>
+		<exclude name="WordPressVIPMinimum"/>
 
-		<!-- The code in this package is not run in the context of a plugin. -->
-		<exclude name="WordPress.WP.AlternativeFunctions"/>
-		<exclude name="Yoast.Yoast.AlternativeFunctions"/>
+		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
+		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- PHP 7.0+. -->
+		<exclude name="PSR12.Properties.ConstantVisibility"/><!-- PHP 7.1+. -->
+		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/><!-- PHP 7.1+. -->
 	</rule>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
-	<rule ref="PSR1.Classes.ClassDeclaration"/>
+	<rule ref="PSR1.Classes.ClassDeclaration">
+		<!-- YoastCS only applies this rule to test files. Overrule it to apply to all files. -->
+		<include-pattern>*\.php</include-pattern>
+	</rule>
 
 
 	<!--
@@ -59,13 +68,21 @@
 	#############################################################################
 	-->
 
+	<rule ref="Yoast.Files.FileName">
+		<properties>
+			<property name="psr4_paths" type="array">
+				<element key="Yoast\WPTestUtils\Tests\\" value="tests/"/>
+			</property>
+		</properties>
+
+		<include-pattern>/tests/*\.php</include-pattern>
+	</rule>
+
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<property name="prefixes" type="array">
-				<element value="Yoast\WPTestUtils"/>
-			</property>
-			<property name="src_directory" type="array">
-				<element value="src"/>
+			<property name="psr4_paths" type="array">
+				<element key="Yoast\WPTestUtils\\" value="src/"/>
+				<element key="Yoast\WPTestUtils\Tests\\" value="tests/"/>
 			</property>
 		</properties>
 	</rule>
@@ -78,7 +95,7 @@
 
 	<rule ref="WordPress.PHP.NoSilencedErrors">
 		<properties>
-			<property name="custom_whitelist" type="array">
+			<property name="customAllowedFunctionsList" type="array">
 				<element value="file_exists"/>
 			</property>
 		</properties>
@@ -91,11 +108,6 @@
 	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
 	#############################################################################
 	-->
-
-	<!-- Allow filecomments in file which don't contain OO declarations. -->
-	<rule ref="Yoast.Commenting.FileComment.Unnecessary">
-		<exclude-pattern>/src/*/bootstrap*\.php$</exclude-pattern>
-	</rule>
 
 	<!-- Declaring a few WordPress native constants. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
@@ -116,9 +128,16 @@
 		<exclude-pattern>/src/Helpers/*\.php$</exclude-pattern>
 	</rule>
 
-	<!-- Ignore word count for object names in tests. -->
+	<!-- TEST CODE -->
+
+	<!-- Final classes is irrelevant for test fixtures. -->
+	<rule ref="Universal.Classes.RequireFinalClass">
+		<exclude-pattern>/tests/*/Fixtures/*\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Ignore word count for object names in test fixtures. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+		<exclude-pattern>/tests/*/Fixtures/*\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Test fixtures are not the actual tests. -->

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"require-dev": {
-		"yoast/yoastcs": "^2.3.1"
+		"php-parallel-lint/php-console-highlighter": "^1.0.0",
+		"php-parallel-lint/php-parallel-lint": "^1.3.2",
+		"yoast/yoastcs": "^3.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,


### PR DESCRIPTION
YoastCS 3.0.0 has been released and is based on WordPressCS 3.0.0.

This commit makes the necessary updates for that:
* Composer: update the requirements.
* PHPCS ruleset: - Exclude new (and more) WP specific rules which don't apply to this package. - Exclude code modernization sniffs which can't be applied to this package yet. - Enforce strict PSR-4 for both src and tests. - Update a few property names for new names in WordPressCS 3.0. - Remove a few exclusions which are no longer needed. - Add a few selective exclusions for specific situations.
* GHA CS workflow: run the CS check on the latest PHP version. No need to run on PHP 7.4 any more as the deprecations previously encountered were all fixed.

While YoastCS 3.0.0 contains lots of goodies, it also has a downside: a minimum PHP requirement of PHP 7.2, which conflicts with the minimum supported PHP version of this package.

This causes two issues:
1. A plain `composer install` will no longer work on PHP < 7.2. This means the YoastCS package will need to be removed for the CI test workfows.
2. As the (Parallel) linting packages are "inherited" from YoastCS, removing YoastCS would break the linting command in CI, so we need to `require-dev` the Parallel Lint packages in PHPUnit Polyfills itself to allow the workflow to continue to work.

With those two work-arounds in place, everything should work again.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0