### PR TITLE
Composer: update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
 	},
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
-		"php-parallel-lint/php-parallel-lint": "^1.3.2",
-		"yoast/yoastcs": "^3.0"
+		"php-parallel-lint/php-parallel-lint": "^1.4.0",
+		"yoast/yoastcs": "^3.1.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require": {
 		"php": ">=5.6",
 		"brain/monkey": "^2.6.1",
-		"yoast/phpunit-polyfills": "^1.1.0"
+		"yoast/phpunit-polyfills": "^1.1.1"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",


### PR DESCRIPTION
### Composer: update dev dependencies

Nearly all dev dependencies have had new releases. This commit updates the plugin to use the new versions.

For linting, the upgrade will get us preliminary PHP 8.4 support.
For CS, the upgrades will get us improved syntax support for PHP 8.3, improved information related to the WP 6.5 release, more documentation and a range of bug fixes.

### Composer: update PHPUnit Polyfills

This upgrade will get us continued support for running the tests via a PHAR file after the latest PHPUnit releases, as well as preliminary PHP 8.4 support.