### PR TITLE
Composer: update BrainMonkey to `^2.6.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"require": {
 		"php": ">=5.6",
-		"brain/monkey": "^2.6.1",
+		"brain/monkey": "^2.6.2",
 		"yoast/phpunit-polyfills": "^1.1.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Set the minimum supported BrainMonkey version to the release which adds compatibility with PHP 8.4.

Refs:
* https://github.com/Brain-WP/BrainMonkey/releases/tag/2.6.2