### PR TITLE
GH Actions/test: anticipate PHP 8.4 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,17 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.4']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.5']
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
         include:
         - php: 5.6
           coverage: true
-        - php: 8.3
+        - php: 8.4
           coverage: true
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     name: "Tests: PHP ${{ matrix.php }}"
 
@@ -51,14 +51,14 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: matrix.php != '8.4'
+        if: matrix.php != '8.5'
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies - ignore PHP restrictions
-        if: matrix.php == '8.4'
+        if: matrix.php == '8.5'
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.4).
* Add _allowed to fail_ build against PHP 8.5.