### PR TITLE
PHPCS: fix bug in ruleset

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,7 +47,10 @@
 		<exclude name="WordPress.Security"/>
 		<exclude name="WordPress.WP"/>
 		<exclude name="Yoast.Yoast.JsonEncodeAlternative"/>
-		<exclude name="WordPressVIPMinimum"/>
+		<exclude name="WordPressVIPMinimum.Classes.DeclarationCompatibility"/>
+		<exclude name="WordPressVIPMinimum.Hooks.AlwaysReturnInFilter"/>
+		<exclude name="WordPressVIPMinimum.Security.EscapingVoidReturnFunctions"/>
+		<exclude name="WordPressVIPMinimum.Security.ProperEscapingFunction"/>
 
 		<!-- Exclude select "modern PHP" sniffs, which conflict with the minimum supported PHP version of this package. -->
 		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- PHP 7.0+. -->


### PR DESCRIPTION
Hmm... this is an awkward one and may need fixing in PHPCS 4.0, but in the mean time, let's fix it here.

The base `Yoast` ruleset includes select sniffs from the `WordPressVIPMinimum` ruleset. These sniff do not apply to the WP TestUtils package.

Now, when an `<exclude name="..."/>` rule references a ruleset name to _exclude_ those sniffs, that whole standard is read and included, after which the individual sniffs from the ruleset are excluded again.

This also means that if such a ruleset _also_ includes sniffs from other standards and/or customizations (changes in severity/excludes/messaging/properties etc) to sniffs from other standards, those sniffs from other standards will still be included and the customizations still be applied.

This will often silently lead to unexpected side-effects, like in the case of the exclusion of the `WordPressVIPMinimum` ruleset, which meant that certain rules we _do_ want applied, like "no superfluous whitespace at the end of a line", got unintentionally excluded.

Fixed now by excluding the individual sniffs from the `WordPressVIPMinimum` standard which were included by the `Yoast` ruleset, instead of excluding the whole `WordPressVIPMinimum` standard.