### PR TITLE
Dependabot: remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
       prefix: "GH Actions:"
     labels:
       - "yoastcs/qa"
-    reviewers:
-      - "jrfnl"
 
   # Maintain dependencies for Composer.
   - package-ecosystem: "composer"
@@ -29,5 +27,3 @@ updates:
       prefix: "Composer:"
     labels:
       - "yoastcs/qa"
-    reviewers:
-      - "jrfnl"


### PR DESCRIPTION
Support for the `reviewers` key in `dependabot.yml` files is being removed by GitHub on May 20th 2025.

The recommendation is to have a `CODEOWNERS` file to set reviewers instead.

For now, this commit removes the `reviewers` key from the `dependabot.yml` file without replacing it. That should prevent comments being left in PRs by the dependabot bot account about the field no longer being supported.

Ref:
* https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location