### PR TITLE
Composer: update to YoastCS 3.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
 	"require-dev": {
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
-		"yoast/yoastcs": "^3.3.0"
+		"yoast/yoastcs": "^3.4.0"
 	},
-	"minimum-stability": "dev",
+	"minimum-stability": "alpha",
 	"prefer-stable": true,
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
This switches the package over to use the PHPCompatibility 10.0-alpha2 version, which should get us much more extensive PHP cross-version compatibility issue detection.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/3.4.0